### PR TITLE
Add GitHub Actions workflow for automatic TestFlight deployment

### DIFF
--- a/.github/workflows/SETUP.md
+++ b/.github/workflows/SETUP.md
@@ -1,0 +1,99 @@
+# GitHub Actions TestFlight Deployment Setup
+
+This document explains how to configure the GitHub Actions workflow to automatically deploy your iOS app to TestFlight when you push to the `development` branch.
+
+## Required GitHub Secrets
+
+You need to configure the following secrets in your GitHub repository settings (Settings → Secrets and variables → Actions → New repository secret):
+
+### 1. Fastlane Match Secrets
+
+These are used to access your certificates and provisioning profiles:
+
+- **MATCH_PASSWORD**: The password used to encrypt your certificates in the match repository
+- **MATCH_GIT_URL**: The git URL of your certificates repository (e.g., `https://github.com/yourusername/certificates`)
+- **MATCH_KEYCHAIN_NAME**: Name for the temporary keychain (e.g., `github_actions_keychain`)
+- **MATCH_KEYCHAIN_PASSWORD**: Password for the temporary keychain (use a strong random password)
+
+### 2. App Store Connect API Key
+
+Instead of using Apple ID credentials, this workflow uses App Store Connect API keys for authentication. This is more secure and doesn't require 2FA handling.
+
+To create an App Store Connect API Key:
+
+1. Go to [App Store Connect](https://appstoreconnect.apple.com/)
+2. Navigate to Users and Access → Keys
+3. Click the "+" button to create a new key
+4. Give it a name (e.g., "GitHub Actions") and select "Developer" or "Admin" access
+5. Download the API key file (it will be named something like `AuthKey_XXXXXXXXXX.p8`)
+6. Note the Key ID and Issuer ID shown on the page
+
+Then add these secrets:
+
+- **APP_STORE_CONNECT_API_KEY_KEY_ID**: The Key ID from App Store Connect (e.g., `ABC123XYZ`)
+- **APP_STORE_CONNECT_API_KEY_ISSUER_ID**: The Issuer ID from App Store Connect (UUID format)
+- **APP_STORE_CONNECT_API_KEY_KEY**: The full content of the `.p8` file you downloaded. Copy the entire file content including the `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` lines.
+
+## Setting Up Fastlane Match (If Not Already Configured)
+
+If you haven't set up Fastlane Match yet:
+
+1. Create a private git repository to store certificates (e.g., `certificates`)
+2. Run `fastlane match init` and follow the prompts
+3. Run `fastlane match appstore` to generate and store your certificates
+4. The MATCH_PASSWORD you set during this process should be added to GitHub secrets
+
+## Updating the Fastfile (If Using API Key)
+
+If you want to use the App Store Connect API key instead of Apple ID authentication, update your `fastlane/Fastfile` to include:
+
+```ruby
+lane :beta do
+  # Set up API Key authentication
+  app_store_connect_api_key(
+    key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+    issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+    key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"]
+  )
+
+  # ... rest of your existing beta lane code
+end
+```
+
+## Testing the Workflow
+
+1. Commit your changes to a feature branch
+2. Push to the `development` branch (or merge your feature branch into development)
+3. Go to the "Actions" tab in your GitHub repository
+4. You should see the "Deploy to TestFlight" workflow running
+5. Click on it to see the detailed logs
+
+## Troubleshooting
+
+### Code Signing Issues
+- Verify that your MATCH_PASSWORD and MATCH_GIT_URL are correct
+- Ensure your match repository contains valid certificates for App Store distribution
+- Run `fastlane match appstore` locally to verify your certificates are valid
+
+### Upload to TestFlight Fails
+- Verify your App Store Connect API key has the correct permissions
+- Check that the API key hasn't expired
+- Ensure your app's bundle identifier matches what's in App Store Connect
+
+### Build Fails
+- Check the build logs in the Actions tab
+- Verify that all CocoaPods dependencies are properly configured
+- Ensure your Xcode project builds successfully locally first
+
+## Workflow Trigger
+
+The workflow is currently configured to trigger on:
+- Push to `development` branch
+
+To add more triggers (like manual trigger or specific tags), modify the `on:` section in `.github/workflows/testflight-deploy.yml`.
+
+## Additional Notes
+
+- The workflow runs on `macos-latest` which provides the latest stable macOS environment with Xcode
+- Build artifacts (logs) are uploaded if the build fails, making debugging easier
+- The temporary keychain is created and destroyed during the build process for security

--- a/.github/workflows/SETUP.md
+++ b/.github/workflows/SETUP.md
@@ -81,13 +81,14 @@ When you push to the `development` branch, the workflow will:
 
 1. ✅ Checkout the code
 2. ✅ Select pinned Xcode version for consistency
-3. ✅ Install CocoaPods dependencies
-4. ✅ Import code signing certificates and provisioning profiles
-5. ✅ Increment build number automatically (validates integer format)
-6. ✅ Build and archive the app using `xcodebuild`
-7. ✅ Export the IPA
-8. ✅ Upload to TestFlight using `xcrun altool`
-9. ✅ Clean up security credentials
+3. ✅ Cache CocoaPods for faster builds
+4. ✅ Install CocoaPods dependencies
+5. ✅ Import code signing certificates and provisioning profiles (with secure file permissions)
+6. ✅ Increment build number automatically (validates integer format)
+7. ✅ Build and archive the app using `xcodebuild`
+8. ✅ Export the IPA
+9. ✅ Upload to TestFlight using `xcrun altool --upload-package`
+10. ✅ Clean up all sensitive files (keychain, certificates, API keys)
 
 ## Testing the Workflow
 
@@ -134,6 +135,12 @@ When you push to the `development` branch, the workflow will:
 - Ensure your API key has "Developer" or "Admin" access
 - Check that the API key hasn't been revoked in App Store Connect
 
+#### Upload package deprecated warning
+
+- The workflow uses `xcrun altool --upload-package` (the current recommended method)
+- If you see deprecation warnings, Apple may be transitioning to newer tools
+- Future-proof alternative: Use the App Store Connect API directly or Transporter app
+
 #### App validation failed
 
 - Ensure your app version and build number are unique
@@ -156,8 +163,10 @@ This native approach has several benefits:
 - ✅ **More transparent**: Direct xcodebuild commands are easier to debug
 - ✅ **Less maintenance**: No need to keep fastlane plugins updated
 - ✅ **Native**: Uses Apple's official command-line tools
-- ✅ **Secure**: API keys stored with restrictive permissions (chmod 600)
+- ✅ **Secure**: API keys and certificates stored with restrictive permissions (chmod 600)
 - ✅ **Consistent**: Pinned macOS and Xcode versions prevent surprises
+- ✅ **Fast**: CocoaPods dependency caching speeds up subsequent builds
+- ✅ **Clean**: Automatic cleanup of all sensitive files after each run
 
 ## Configuration
 
@@ -172,6 +181,17 @@ env:
 ```
 
 Update these values if your project configuration differs.
+
+### Build Number Strategy
+
+The workflow increments the build number based on the current value in `Info.plist`. However, for guaranteed uniqueness across parallel or concurrent builds, you can use GitHub's run number instead:
+
+In the workflow file, uncomment this line in the "Increment Build Number" step:
+```yaml
+# NEW_BUILD=${{ github.run_number }}
+```
+
+This ensures each build has a unique, monotonically increasing build number.
 
 ## Optional: Manual Trigger
 

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -22,6 +22,14 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
 
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
       - name: Install CocoaPods
         run: |
           sudo gem install cocoapods
@@ -40,9 +48,12 @@ jobs:
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
-          # Import certificate
-          echo "$CERTIFICATE_BASE64" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
-          security import "$RUNNER_TEMP/certificate.p12" \
+          # Import certificate with secure permissions
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          echo "$CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+          chmod 600 "$CERT_PATH"
+
+          security import "$CERT_PATH" \
             -k "$KEYCHAIN_PATH" \
             -P "$P12_PASSWORD" \
             -T /usr/bin/codesign \
@@ -73,7 +84,9 @@ jobs:
             exit 1
           fi
 
-          # Increment build number
+          # Increment build number (or use GitHub run number for guaranteed uniqueness)
+          # Uncomment next line to use GitHub run number instead:
+          # NEW_BUILD=${{ github.run_number }}
           NEW_BUILD=$((CURRENT_BUILD + 1))
           /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $NEW_BUILD" teachMe/Info.plist
           echo "New build number: $NEW_BUILD"
@@ -131,25 +144,39 @@ jobs:
           APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         run: |
           # Create API key directory
-          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          API_KEY_DIR="$HOME/.appstoreconnect/private_keys"
+          API_KEY_PATH="$API_KEY_DIR/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          mkdir -p "$API_KEY_DIR"
 
           # Save API key to file with base64 decoding and secure permissions
-          echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$API_KEY_PATH"
+          chmod 600 "$API_KEY_PATH"
 
-          # Upload to TestFlight
-          xcrun altool --upload-app \
+          # Upload to TestFlight using --upload-package (replacement for deprecated --upload-app)
+          xcrun altool --upload-package "$RUNNER_TEMP/export/teachMe.ipa" \
             --type ios \
-            --file "$RUNNER_TEMP/export/teachMe.ipa" \
             --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
             --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"
 
-      - name: Clean up keychain
+      - name: Clean up sensitive files
         if: always()
         run: |
+          # Remove keychain
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
           if [ -f "$KEYCHAIN_PATH" ]; then
             security delete-keychain "$KEYCHAIN_PATH"
+          fi
+
+          # Remove certificate file
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+          if [ -f "$CERT_PATH" ]; then
+            rm -f "$CERT_PATH"
+          fi
+
+          # Remove API key file
+          API_KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          if [ -f "$API_KEY_PATH" ]; then
+            rm -f "$API_KEY_PATH"
           fi
 
       - name: Upload build artifacts

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -5,13 +5,22 @@ on:
     branches:
       - development
 
+env:
+  XCODE_VERSION: '15.2'
+  BUNDLE_IDENTIFIER: 'petitcoding.com.teachMe'
+  DEVELOPMENT_TEAM: 'AMLYNCKP6M'
+  PROVISIONING_PROFILE_SPECIFIER: 'match AppStore petitcoding.com.teachMe'
+
 jobs:
   build-and-deploy:
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
 
       - name: Install CocoaPods
         run: |
@@ -32,8 +41,8 @@ jobs:
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           # Import certificate
-          echo "$CERTIFICATE_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
-          security import $RUNNER_TEMP/certificate.p12 \
+          echo "$CERTIFICATE_BASE64" | base64 --decode > "$RUNNER_TEMP/certificate.p12"
+          security import "$RUNNER_TEMP/certificate.p12" \
             -k "$KEYCHAIN_PATH" \
             -P "$P12_PASSWORD" \
             -T /usr/bin/codesign \
@@ -48,14 +57,21 @@ jobs:
           PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
         run: |
           # Decode and install provisioning profile
-          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
-          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$HOME/Library/MobileDevice/Provisioning Profiles/profile.mobileprovision"
 
       - name: Increment Build Number
         run: |
           # Get the current build number
           CURRENT_BUILD=$(/usr/libexec/PlistBuddy -c "Print CFBundleVersion" teachMe/Info.plist)
           echo "Current build number: $CURRENT_BUILD"
+
+          # Validate that build number is a positive integer
+          if ! [[ "$CURRENT_BUILD" =~ ^[0-9]+$ ]]; then
+            echo "Error: CFBundleVersion must be a positive integer, found: $CURRENT_BUILD"
+            echo "If using semantic versioning, use CFBundleShortVersionString instead"
+            exit 1
+          fi
 
           # Increment build number
           NEW_BUILD=$((CURRENT_BUILD + 1))
@@ -68,15 +84,15 @@ jobs:
             -workspace teachMe.xcworkspace \
             -scheme teachMe \
             -configuration Release \
-            -archivePath $RUNNER_TEMP/teachMe.xcarchive \
+            -archivePath "$RUNNER_TEMP/teachMe.xcarchive" \
             CODE_SIGN_IDENTITY="iPhone Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="match AppStore petitcoding.com.teachMe" \
-            DEVELOPMENT_TEAM="AMLYNCKP6M"
+            PROVISIONING_PROFILE_SPECIFIER="${{ env.PROVISIONING_PROFILE_SPECIFIER }}" \
+            DEVELOPMENT_TEAM="${{ env.DEVELOPMENT_TEAM }}"
 
       - name: Export IPA
         run: |
           # Create export options plist
-          cat > $RUNNER_TEMP/ExportOptions.plist << EOF
+          cat > "$RUNNER_TEMP/ExportOptions.plist" << EOF
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -84,7 +100,7 @@ jobs:
             <key>method</key>
             <string>app-store</string>
             <key>teamID</key>
-            <string>AMLYNCKP6M</string>
+            <string>${{ env.DEVELOPMENT_TEAM }}</string>
             <key>uploadBitcode</key>
             <false/>
             <key>compileBitcode</key>
@@ -95,8 +111,8 @@ jobs:
             <string>manual</string>
             <key>provisioningProfiles</key>
             <dict>
-              <key>petitcoding.com.teachMe</key>
-              <string>match AppStore petitcoding.com.teachMe</string>
+              <key>${{ env.BUNDLE_IDENTIFIER }}</key>
+              <string>${{ env.PROVISIONING_PROFILE_SPECIFIER }}</string>
             </dict>
           </dict>
           </plist>
@@ -104,21 +120,24 @@ jobs:
 
           # Export archive to IPA
           xcodebuild -exportArchive \
-            -archivePath $RUNNER_TEMP/teachMe.xcarchive \
-            -exportPath $RUNNER_TEMP/export \
-            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist
+            -archivePath "$RUNNER_TEMP/teachMe.xcarchive" \
+            -exportPath "$RUNNER_TEMP/export" \
+            -exportOptionsPlist "$RUNNER_TEMP/ExportOptions.plist"
 
       - name: Upload to TestFlight
         env:
           APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          APP_STORE_CONNECT_API_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_API_KEY_BASE64 }}
         run: |
-          # Save API key to file
-          mkdir -p ~/.appstoreconnect/private_keys
-          echo "$APP_STORE_CONNECT_API_KEY_CONTENT" > ~/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
+          # Create API key directory
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
 
-          # Upload to TestFlight using altool (older method) or notarytool
+          # Save API key to file with base64 decoding and secure permissions
+          echo "$APP_STORE_CONNECT_API_KEY_BASE64" | base64 --decode > "$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+          chmod 600 "$HOME/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+
+          # Upload to TestFlight
           xcrun altool --upload-app \
             --type ios \
             --file "$RUNNER_TEMP/export/teachMe.ipa" \

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -13,38 +13,125 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.0'
-          bundler-cache: true
-
-      - name: Install dependencies
-        run: |
-          gem install bundler
-          bundle install
-
       - name: Install CocoaPods
         run: |
-          gem install cocoapods
+          sudo gem install cocoapods
           pod install
 
-      - name: Set up App Store Connect API Key
-        run: |
-          mkdir -p ~/.appstoreconnect/private_keys
-          echo "${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}" > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}.p8
-
-      - name: Build and Deploy to TestFlight
+      - name: Import Code Signing Certificates
         env:
-          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
-          MATCH_KEYCHAIN_NAME: ${{ secrets.MATCH_KEYCHAIN_NAME }}
-          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
-          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          CERTIFICATE_BASE64: ${{ secrets.CERTIFICATE_BASE64 }}
         run: |
-          bundle exec fastlane beta
+          # Create keychain
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Import certificate
+          echo "$CERTIFICATE_BASE64" | base64 --decode > $RUNNER_TEMP/certificate.p12
+          security import $RUNNER_TEMP/certificate.p12 \
+            -k "$KEYCHAIN_PATH" \
+            -P "$P12_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+
+          # Set keychain as default
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+      - name: Import Provisioning Profile
+        env:
+          PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          # Decode and install provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > ~/Library/MobileDevice/Provisioning\ Profiles/profile.mobileprovision
+
+      - name: Increment Build Number
+        run: |
+          # Get the current build number
+          CURRENT_BUILD=$(/usr/libexec/PlistBuddy -c "Print CFBundleVersion" teachMe/Info.plist)
+          echo "Current build number: $CURRENT_BUILD"
+
+          # Increment build number
+          NEW_BUILD=$((CURRENT_BUILD + 1))
+          /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $NEW_BUILD" teachMe/Info.plist
+          echo "New build number: $NEW_BUILD"
+
+      - name: Build Archive
+        run: |
+          xcodebuild archive \
+            -workspace teachMe.xcworkspace \
+            -scheme teachMe \
+            -configuration Release \
+            -archivePath $RUNNER_TEMP/teachMe.xcarchive \
+            CODE_SIGN_IDENTITY="iPhone Distribution" \
+            PROVISIONING_PROFILE_SPECIFIER="match AppStore petitcoding.com.teachMe" \
+            DEVELOPMENT_TEAM="AMLYNCKP6M"
+
+      - name: Export IPA
+        run: |
+          # Create export options plist
+          cat > $RUNNER_TEMP/ExportOptions.plist << EOF
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>method</key>
+            <string>app-store</string>
+            <key>teamID</key>
+            <string>AMLYNCKP6M</string>
+            <key>uploadBitcode</key>
+            <false/>
+            <key>compileBitcode</key>
+            <false/>
+            <key>uploadSymbols</key>
+            <true/>
+            <key>signingStyle</key>
+            <string>manual</string>
+            <key>provisioningProfiles</key>
+            <dict>
+              <key>petitcoding.com.teachMe</key>
+              <string>match AppStore petitcoding.com.teachMe</string>
+            </dict>
+          </dict>
+          </plist>
+          EOF
+
+          # Export archive to IPA
+          xcodebuild -exportArchive \
+            -archivePath $RUNNER_TEMP/teachMe.xcarchive \
+            -exportPath $RUNNER_TEMP/export \
+            -exportOptionsPlist $RUNNER_TEMP/ExportOptions.plist
+
+      - name: Upload to TestFlight
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+        run: |
+          # Save API key to file
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "$APP_STORE_CONNECT_API_KEY_CONTENT" > ~/.appstoreconnect/private_keys/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8
+
+          # Upload to TestFlight using altool (older method) or notarytool
+          xcrun altool --upload-app \
+            --type ios \
+            --file "$RUNNER_TEMP/export/teachMe.ipa" \
+            --apiKey "$APP_STORE_CONNECT_API_KEY_ID" \
+            --apiIssuer "$APP_STORE_CONNECT_ISSUER_ID"
+
+      - name: Clean up keychain
+        if: always()
+        run: |
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+          if [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH"
+          fi
 
       - name: Upload build artifacts
         if: failure()
@@ -52,5 +139,4 @@ jobs:
         with:
           name: build-logs
           path: |
-            ~/Library/Logs/gym
-            fastlane/report.xml
+            ${{ runner.temp }}/*.log

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy to TestFlight
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  build-and-deploy:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+          bundler-cache: true
+
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: Install CocoaPods
+        run: |
+          gem install cocoapods
+          pod install
+
+      - name: Set up App Store Connect API Key
+        run: |
+          mkdir -p ~/.appstoreconnect/private_keys
+          echo "${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}" > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}.p8
+
+      - name: Build and Deploy to TestFlight
+        env:
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_KEYCHAIN_NAME: ${{ secrets.MATCH_KEYCHAIN_NAME }}
+          MATCH_KEYCHAIN_PASSWORD: ${{ secrets.MATCH_KEYCHAIN_PASSWORD }}
+          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY_ID }}
+          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY_KEY }}
+        run: |
+          bundle exec fastlane beta
+
+      - name: Upload build artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: |
+            ~/Library/Logs/gym
+            fastlane/report.xml

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -160,6 +160,8 @@ jobs:
 
       - name: Clean up sensitive files
         if: always()
+        env:
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
         run: |
           # Remove keychain
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,6 +21,15 @@ platform :ios do
   #setup_travis
   #xcversion(version: "10.2
 
+  # Set up App Store Connect API Key for authentication
+      if ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"] && ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"] && ENV["APP_STORE_CONNECT_API_KEY_KEY"]
+        app_store_connect_api_key(
+          key_id: ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"],
+          issuer_id: ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"],
+          key_content: ENV["APP_STORE_CONNECT_API_KEY_KEY"]
+        )
+      end
+
   # Fetch the keychain env variables
       # securely stored in the travis.yml.
       keychain_name = ENV["MATCH_KEYCHAIN_NAME"]


### PR DESCRIPTION
- Create GitHub Actions workflow that triggers on push to development branch
- Workflow builds iOS app and uploads to TestFlight using existing fastlane setup
- Update Fastfile to support App Store Connect API key authentication
- Add comprehensive setup documentation with required secrets and troubleshooting guide

The workflow automates the TestFlight deployment process, eliminating manual builds
and ensuring consistent deployments for every commit to the development branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI/CD workflow to build and deploy the iOS app from the development branch to TestFlight, including automated build numbering, artifact cleanup, failure log uploads, and optional manual trigger.
  * Added App Store Connect API key support for authenticated automated deployments.

* **Documentation**
  * Added a comprehensive setup guide covering workflow configuration, required credentials handling, testing steps, troubleshooting, and a how-it-works overview for native TestFlight deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->