### PR TITLE
Fix provisioning profile application to CocoaPods targets

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -67,9 +67,18 @@ jobs:
         env:
           PROVISIONING_PROFILE_BASE64: ${{ secrets.PROVISIONING_PROFILE_BASE64 }}
         run: |
-          # Decode and install provisioning profile
+          # Decode and install provisioning profile with correct UUID filename
+          PROFILE_PATH="$RUNNER_TEMP/profile.mobileprovision"
+          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+
+          # Extract UUID from provisioning profile
+          UUID=$(/usr/libexec/PlistBuddy -c "Print :UUID" /dev/stdin <<< $(security cms -D -i "$PROFILE_PATH"))
+
+          # Copy to Xcode provisioning profiles directory with UUID as filename
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          echo "$PROVISIONING_PROFILE_BASE64" | base64 --decode > "$HOME/Library/MobileDevice/Provisioning Profiles/profile.mobileprovision"
+          cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles/$UUID.mobileprovision"
+
+          echo "Installed provisioning profile with UUID: $UUID"
 
       - name: Increment Build Number
         run: |
@@ -98,8 +107,8 @@ jobs:
             -scheme teachMe \
             -configuration Release \
             -archivePath "$RUNNER_TEMP/teachMe.xcarchive" \
-            CODE_SIGN_IDENTITY="iPhone Distribution" \
-            PROVISIONING_PROFILE_SPECIFIER="${{ env.PROVISIONING_PROFILE_SPECIFIER }}" \
+            -allowProvisioningUpdates \
+            CODE_SIGN_STYLE=Manual \
             DEVELOPMENT_TEAM="${{ env.DEVELOPMENT_TEAM }}"
 
       - name: Export IPA
@@ -120,13 +129,6 @@ jobs:
             <false/>
             <key>uploadSymbols</key>
             <true/>
-            <key>signingStyle</key>
-            <string>manual</string>
-            <key>provisioningProfiles</key>
-            <dict>
-              <key>${{ env.BUNDLE_IDENTIFIER }}</key>
-              <string>${{ env.PROVISIONING_PROFILE_SPECIFIER }}</string>
-            </dict>
           </dict>
           </plist>
           EOF


### PR DESCRIPTION
Issue: Build was failing because PROVISIONING_PROFILE_SPECIFIER was being applied globally to all targets including CocoaPods dependencies, which don't support provisioning profiles.

Fixes:
1. Removed PROVISIONING_PROFILE_SPECIFIER from xcodebuild archive command
2. Added -allowProvisioningUpdates flag to let Xcode handle profile selection
3. Set CODE_SIGN_STYLE=Manual with DEVELOPMENT_TEAM for proper code signing
4. Fixed provisioning profile installation to use UUID as filename
   - Extract UUID from .mobileprovision file
   - Install with correct filename: UUID.mobileprovision
5. Simplified ExportOptions.plist to remove manual profile specification
   - Xcode now automatically selects the right profile based on bundle ID and team

This allows Xcode to automatically match the provisioning profile for the main app target while leaving CocoaPods targets to use automatic signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal build system and deployment configuration to improve provisioning profile handling and code signing processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->